### PR TITLE
Use AsyncStorage from the standalone package as the react-native one is deprecated

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -15,15 +15,13 @@
 # Ignore unexpected extra @providesModule
 .*/node_modules/commoner/test/source/widget/share.js
 .*/node_modules/fbemitter/node_modules/.*
-.*/node_modules/react-native/.*
+.*/node_modules/@react-native-community/async-storage/.*
 .*/node_modules/metro-bundler/.*
 .*/node_modules/jest-runtime/build/__tests__/.*
 
 <PROJECT_ROOT>/example/.*
 
 [libs]
-node_modules/react-native/Libraries/react-native/react-native-interface.js
-node_modules/react-native/flow/
 flow-typed/.*
 
 [options]
@@ -38,12 +36,12 @@ experimental.strict_type_args=true
 
 munge_underscores=true
 
-module.name_mapper='react-native' -> 'emptyObject'
-
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FlowIgnore
 suppress_type=$FixMe
+
+module.name_mapper='@react-native-community/async-storage' -> 'emptyObject'
 
 unsafe.enable_getters_and_setters=true
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lodash.merge": "^4.6.0"
   },
   "peerDependencies": {
-    "react-native": "^0.38"
+    "@react-native-community/async-storage": "^1.5.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/src/index.mobile.js
+++ b/src/index.mobile.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import { AsyncStorage } from 'react-native';
+import { AsyncStorage } from '@react-native-community/async-storage';
 import type { TAsyncStorage } from './types';
 
 const API: TAsyncStorage = {


### PR DESCRIPTION
### Summary

React Native has deprecated the Async Storage in its core library and ported to a standalone package. This pull request uses the Async Storage from this package instead (@react-native-community/async-storage).
